### PR TITLE
Include video metadata (so far: duration) in Asset file metadata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       contentful (>= 2.11.1, < 3.0.0)
       mongoid (>= 7.0.2, < 8.0.0)
       rainbow
+      streamio-ffmpeg
 
 GEM
   remote: https://rubygems.org/
@@ -21,6 +22,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     bson (4.7.1)
+    coderay (1.1.2)
     concurrent-ruby (1.1.5)
     contentful (2.15.2)
       http (> 0.8, < 5.0)
@@ -46,6 +48,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    method_source (0.9.2)
     minitest (5.14.0)
     mongo (2.11.3)
       bson (>= 4.4.2, < 5.0.0)
@@ -56,6 +59,9 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (4.0.3)
     rainbow (3.0.0)
     rake (10.5.0)
@@ -80,6 +86,8 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
+    streamio-ffmpeg (3.0.2)
+      multi_json (~> 1.8)
     thread_safe (0.3.6)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
@@ -95,9 +103,10 @@ DEPENDENCIES
   bundler (~> 2)
   consyncful!
   database_cleaner
+  pry
   rake (~> 10.0)
   rspec (~> 3.0)
   rubocop (= 0.79.0)
 
 BUNDLED WITH
-   2.1.0
+   2.1.4

--- a/consyncful.gemspec
+++ b/consyncful.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'database_cleaner'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '0.79.0'
@@ -40,4 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'contentful', ['>=2.11.1', '<3.0.0']
   spec.add_dependency 'mongoid', ['>=7.0.2', '<8.0.0']
   spec.add_dependency 'rainbow'
+  spec.add_dependency 'streamio-ffmpeg'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require 'bundler/setup'
 require 'consyncful'
 require 'database_cleaner'
+require 'pry'
 
 Mongoid.load!('spec/support/mongoid.yml', :test)
 


### PR DESCRIPTION
This change is made to support a use-case for the Archives Online Channel web app.
We're now embedding videos that have been uploaded to Contentful. We need to display the duration, and prefer to be able to pull that metadata from the DB rather than calculate it on page load.
Therefore, we've added the duration into the file fields.
Other video metadata (or different asset metadata) could also be included in future, if necessary.