### PR TITLE
Fix — mongo client config applies to Sync 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    consyncful (0.6.0)
+    consyncful (0.6.1)
       contentful (>= 2.11.1, < 3.0.0)
       hooks (>= 0.4.1)
       mongoid (>= 7.0.2, < 8.0.0)

--- a/lib/consyncful/sync.rb
+++ b/lib/consyncful/sync.rb
@@ -19,6 +19,8 @@ module Consyncful
     include Mongoid::Document
     include Hooks
 
+    store_in client: -> { Consyncful.configuration.mongo_client }
+
     define_hook :before_run
     define_hook :after_run
 

--- a/lib/consyncful/version.rb
+++ b/lib/consyncful/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Consyncful
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
Store the sync in the configured mongo client as well as the base class. Otherwise, sync uses `default` while base uses the configured option (e.g. `consyncful`). They should both use the configured option, anything else is madness.