### PR TITLE
Fix Rails 7 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    consyncful (0.6.1)
+    consyncful (0.6.2)
       contentful (>= 2.11.1, < 3.0.0)
       hooks (>= 0.4.1)
       mongoid (>= 7.0.2, < 8.0.0)

--- a/lib/consyncful/tasks/consyncful.rake
+++ b/lib/consyncful/tasks/consyncful.rake
@@ -19,7 +19,7 @@ namespace :consyncful do
   end
 
   task update_model_names: [:environment] do
-    if Object.const_defined?('Zeitwerk::Loader') && Rails.application.config.autoloader.to_s == 'zeitwerk'
+    if Rails.autoloaders.zeitwerk_enabled?
       Zeitwerk::Loader.eager_load_all
     else
       Rails.application.eager_load!

--- a/lib/consyncful/version.rb
+++ b/lib/consyncful/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Consyncful
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end


### PR DESCRIPTION
- `Rails.application.config.autoloader.to_s` breaks on Rails 7 apps because `autoloaders` doesn't exists.
- Use `zeitwerk_enabled?` instead to check for Zeitwork loader. This method is available in Rails 6.

