### PR TITLE
Preserve Contentful Timestamps

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,7 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 # IgnoredMethods: refine
 Metrics/BlockLength:
-  Max: 211
+  Max: 220
 
 # Offense count: 3
 # This cop supports safe auto-correction (--auto-correct).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    consyncful (0.7.0)
+    consyncful (0.7.1)
       contentful (>= 2.11.1, < 3.0.0)
       hooks (>= 0.4.1)
       mongoid (>= 7.0.2, < 8.0.0)
@@ -10,9 +10,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.2.4)
-      activesupport (= 7.0.2.4)
-    activesupport (7.0.2.4)
+    activemodel (7.0.3)
+      activesupport (= 7.0.3)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -22,14 +22,14 @@ GEM
     ast (2.4.2)
     bson (4.15.0)
     concurrent-ruby (1.1.10)
-    contentful (2.16.0)
+    contentful (2.16.3)
       http (> 0.8, < 5.0)
       multi_json (~> 1)
     database_cleaner (1.8.3)
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.15.0)
+    ffi (1.15.5)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -40,14 +40,14 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       http-parser (~> 1.2.0)
-    http-cookie (1.0.3)
+    http-cookie (1.0.5)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     http-parser (1.2.3)
       ffi-compiler (>= 1.0, < 2.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.15.0)
+    minitest (5.16.2)
     mongo (2.17.1)
       bson (>= 4.8.2, < 5.0.0)
     mongoid (7.4.0)
@@ -58,7 +58,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
     rainbow (3.1.1)
     rake (13.0.1)
     regexp_parser (2.3.1)
@@ -98,7 +98,7 @@ GEM
     uber (0.0.15)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.7)
+    unf_ext (0.0.8.2)
     unicode-display_width (2.1.0)
 
 PLATFORMS

--- a/README.md
+++ b/README.md
@@ -165,6 +165,19 @@ end
 
 If fields have multiple locales then the default locale will be mapped to the field name. Additional locales will have a suffix (lower snake case) on the field name. e.g title (default), title_mi_nz (New Zealand Maori mi-NZ)
 
+### Preserving Contentful timestamps
+
+If you need to access the timestamps from Contentful, you can enable it by setting `preserve_contentful_timestamps` to `true`.
+
+```rb
+Consyncful.configure do |config|
+  # Consyncful models will have two extra fields that contains the value of timestamps in Contentful.
+  # contentful_created_at
+  # contentful_updated_at
+  config.preserve_contentful_timestamps = true # defaults to false
+end
+```
+
 ### Sync specific contents using [Contentful Tag](https://www.contentful.com/help/tags/).
 You can configure Consyncful to sync or ignore specific contents using Contentful Tag.
 

--- a/lib/consyncful.rb
+++ b/lib/consyncful.rb
@@ -18,7 +18,8 @@ module Consyncful
                   :mongo_client,
                   :mongo_collection,
                   :content_tags,
-                  :ignore_content_tags
+                  :ignore_content_tags,
+                  :preserve_contentful_timestamps
 
     def initialize
       @contentful_client_options = {
@@ -29,6 +30,7 @@ module Consyncful
       @mongo_collection = 'contentful_models'
       @content_tags = []
       @ignore_content_tags = []
+      @preserve_contentful_timestamps = false
     end
   end
 

--- a/lib/consyncful/item_mapper.rb
+++ b/lib/consyncful/item_mapper.rb
@@ -36,6 +36,7 @@ module Consyncful
 
       fields.merge!(localized_fields(default_locale))
       fields.merge!(localized_asset_fields(default_locale)) if type == 'asset'
+      fields.merge!(contentful_timestamps) if Consyncful.configuration.preserve_contentful_timestamps
 
       fields
     end
@@ -49,11 +50,13 @@ module Consyncful
     end
 
     def generic_fields
-      { created_at: @item.created_at,
+      {
+        created_at: @item.created_at,
         updated_at: @item.updated_at,
         revision: @item.revision,
         contentful_type: type,
-        synced_at: Time.current }
+        synced_at: Time.current
+      }
     end
 
     def localized_fields(default_locale)
@@ -112,6 +115,13 @@ module Consyncful
       else
         [field, value]
       end
+    end
+
+    def contentful_timestamps
+      {
+        contentful_created_at: @item.created_at,
+        contentful_updated_at: @item.updated_at
+      }
     end
   end
 end

--- a/lib/consyncful/version.rb
+++ b/lib/consyncful/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Consyncful
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end

--- a/spec/consyncful/item_mapper_spec.rb
+++ b/spec/consyncful/item_mapper_spec.rb
@@ -174,6 +174,15 @@ RSpec.describe Consyncful::ItemMapper do
         )
       end
     end
+
+    context 'when preserve_contentful_timestamps is enabled' do
+      it 'returns the additional contentful timestamps' do
+        Consyncful.configuration.preserve_contentful_timestamps = true
+
+        expect(item.mapped_fields(default_locale)).to include(contentful_created_at: DateTime.parse('2019-02-20T00:50:17.357Z'))
+        expect(item.mapped_fields(default_locale)).to include(contentful_updated_at: DateTime.parse('2019-02-20T00:50:50.052Z'))
+      end
+    end
   end
 
   describe '#deletion?' do


### PR DESCRIPTION
**The problem**

When consyncful syncs the data from Contentful, it saves the `updated_at` and `created_at` timestamps to the Mongoid document. This is fine in most cases. However, `updated_at` can be easily overwritten in the app by calling `.touch`.

One case is when we use a model in a cache block. In order for us to invalidate the cache, we need to update the `updated_at`. By doing this, the new `updated_at` value doesn't reflect the original timestamps from Contentful.

This is important for pages that display when the page/model gets the last update. Also useful for `sitemap.xml` that should reflect the original timestamps from Contentful.

**Usage:**

Add a new configuration in `consyncful.rb`:

```ruby
Consyncful.configure do |config|
  ...
  # Adds two new fields that holds the original contentful timestamps
  config.preserve_contentful_timestamps = true
end
```

Each model will have two new fields that can be used for the app.

```ruby
model.contentful_created_at
model.contentful_updated_at
```

These new fields will refresh it's value during the sync (if there are changes).