### PR TITLE
Make Contentful tags available in the Consyncful models

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    consyncful (0.8.0)
+    consyncful (0.9.0)
       contentful (>= 2.11.1, < 3.0.0)
       hooks (>= 0.4.1)
       mongoid (>= 7.0.2, < 9.0.0)

--- a/lib/consyncful/item_mapper.rb
+++ b/lib/consyncful/item_mapper.rb
@@ -55,6 +55,7 @@ module Consyncful
         updated_at: @item.updated_at,
         revision: @item.revision,
         contentful_type: type,
+        contentful_tags: @item._metadata[:tags].map(&:id),
         synced_at: Time.current
       }
     end

--- a/lib/consyncful/version.rb
+++ b/lib/consyncful/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Consyncful
-  VERSION = '0.8.0'
+  VERSION = '0.9.0'
 end

--- a/spec/consyncful/item_mapper_spec.rb
+++ b/spec/consyncful/item_mapper_spec.rb
@@ -63,6 +63,11 @@ RSpec.describe Consyncful::ItemMapper do
             'contentType' => 'image/jpeg'
           }
         }
+      },
+      'metadata' => {
+        'tags' => [
+          { 'sys' => { 'type' => 'Link', 'linkType' => 'Tag', 'id' => 'tag1' } }
+        ]
       }
     }
   end
@@ -111,6 +116,10 @@ RSpec.describe Consyncful::ItemMapper do
       dummy_time = double('time')
       expect(Time).to receive(:current).and_return(dummy_time)
       expect(item.mapped_fields(default_locale)).to include(synced_at: dummy_time)
+    end
+
+    it 'returns a field called contentful_tags with the tag ids' do
+      expect(item.mapped_fields(default_locale)).to include(contentful_tags: ['tag1'])
     end
 
     it 'returns all content model specific fields from the default locale' do


### PR DESCRIPTION
Tags added to content in Contentful are available as `contentful_tags`