### PR TITLE
Make sure consume_webhook_signal returns false when not set

### DIFF
--- a/lib/consyncful/sync.rb
+++ b/lib/consyncful/sync.rb
@@ -43,7 +43,10 @@ module Consyncful
     ##
     # Consume the webhook signal and set webhook_pending to false
     def self.consume_webhook_signal!
+      return false unless latest.webhook_pending?
+
       latest.set(webhook_pending: false)
+      true
     end
 
     ##

--- a/lib/consyncful/tasks/consyncful.rake
+++ b/lib/consyncful/tasks/consyncful.rake
@@ -21,7 +21,7 @@ namespace :consyncful do
 
     seconds = args[:seconds]
     mode = Consyncful.configuration&.sync_mode || :poll
-    puts "mode=#{mode.inspect} interval=#{seconds.inspect}s"
+    puts "mode=#{mode.inspect} interval=#{(seconds || 15).inspect}s"
 
     Consyncful::SyncRunner.new(seconds: seconds, mode: mode).run
   end


### PR DESCRIPTION
Make sure consume_webhook_signal returns false when not set, otherwise the sync job remains polling.