### PR TITLE
Fix: convert interval to integer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    consyncful (1.1.1)
+    consyncful (1.1.2)
       contentful (>= 2.11.1, < 3.0.0)
       hooks (>= 0.4.1)
       mongoid (>= 7.0.2)

--- a/lib/consyncful/sync_runner.rb
+++ b/lib/consyncful/sync_runner.rb
@@ -17,7 +17,7 @@ module Consyncful
     VALID_MODES = %i[poll webhook].freeze
 
     def initialize(seconds: nil, mode: nil)
-      @interval = seconds || DEFAULT_INTERVAL
+      @interval = seconds&.to_i || DEFAULT_INTERVAL
       @mode     = validate_mode(mode)
     end
 

--- a/lib/consyncful/version.rb
+++ b/lib/consyncful/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Consyncful
-  VERSION = '1.1.1'
+  VERSION = '1.1.2'
 end


### PR DESCRIPTION
Interval is passed from the command line, so it's by default a string